### PR TITLE
Fixes for EmoTracker support

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -3033,7 +3033,7 @@
 			"SubPET,Needle,PETCase", // 5 + 3 + 3
 			"SubPET,Needle,CBeacPas,Press", // 5 + 3 + 1 + 2
 			"Needle,PETCase,CBeacPas,Press,CSciPas", // 3 + 3 + 1 + 2 + 2
-			"$hasEnoughRanks,PETCase" // 999 + 3
+			//"$hasEnoughRanks,PETCase" // 999 + 3
 		]
 	},
 	// AKA 12+ explore Score

--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -23,9 +23,9 @@ Tracker:AddMaps("maps/maps.json")
 Tracker:AddLocations("locations/locations.json")
 Tracker:AddLocations("locations/JobLocations.json")
 
-Tracker:AddLayouts("layouts/tracker_standard.json")
 Tracker:AddLayouts("layouts/common.json")
 Tracker:AddLayouts("layouts/items.json")
+Tracker:AddLayouts("layouts/tracker_standard.json")
 Tracker:AddLayouts("layouts/broadcast_standard.json")
 
 -- AutoTracking for Poptracker


### PR DESCRIPTION
Swapping the load order in init.lua makes it so the package works in EmoTracker out of the box as well. I commented out the hasEnoughRanks because the function doesn't exist so it might just be a missing commit somewhere?